### PR TITLE
Added name attribute in metadata.rb to support berkshelf >= 3.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+name             "runit-man"
 maintainer       "Akzhan Abdulin"
 maintainer_email "akzhan.abdulin@gmail.com"
 license          "Apache License 2.0"


### PR DESCRIPTION
metadata: name attribute is required in berkshelf >= 3.0.0

https://github.com/berkshelf/berkshelf/issues/1197
